### PR TITLE
make whitespace parsing work

### DIFF
--- a/src/services/cookie.ts
+++ b/src/services/cookie.ts
@@ -12,7 +12,7 @@ export class Cookie {
 	public static getCookie(name: string): string {
 		let myWindow: any = window;
 		name = myWindow.escape(name);
-		let regexp = new RegExp('(?:^' + name + '|;\s*' + name + ')=(.*?)(?:;|$)', 'g');
+		let regexp = new RegExp('(?:^' + name + '|;\\s*' + name + ')=(.*?)(?:;|$)', 'g');
 		let result = regexp.exec(document.cookie);
 		return (result === null) ? null : myWindow.unescape(result[1]);
 	}


### PR DESCRIPTION
getting null from `getCookie` when key contains an whitespace. this fixs the issue and the cookie name could be resolved to the real cookie-name.

example:
`\smycookie=abc` returns null while `mycookie=abc` returns `abc`
