### PR TITLE
Changes the build to NGC and fixes delete bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ npm-debug.log
 *.map
 *.d.ts
 
+# NGC
+*.metadata.json
+
 # JetBrains
 .idea
 .project

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"typescript.tsdk": "./node_modules/typescript/lib"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-	"typescript.tsdk": "./node_modules/typescript/lib"
+	"typescript.tsdk": "./node_modules/typescript/lib",
+	"vsicons.presets.angular": false
 }

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export * from './src/cookie';

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "ng2-cookies",
   "version": "1.0.4",
   "scripts": {
-    "test": "tsc && karma start",
-    "prepublish": "tsc --outDir .",
-    "tsc": "tsc"
+    "test": "ngc && karma start",
+    "prepublish": "ngc",
+    "ngc": "ngc"
   },
   "repository": {
     "type": "git",
@@ -24,16 +24,18 @@
     "url": "https://github.com/BCJTI/ng2-cookies/issues"
   },
   "main": "index.js",
-  "typings": "./index.d.ts",
-  "dependencies": {},
+  "module": "index.js",
+  "typings": "index.d.ts",
   "devDependencies": {
-    "typescript": "^1.7.3"
+    "@angular/compiler": "^2.4.8",
+    "@angular/compiler-cli": "^2.4.8",
+    "@angular/core": "^2.4.8",
+    "rxjs": "^5.2.0",
+    "typescript": "^2.2.1",
+    "zone.js": "^0.7.7"
   },
   "engines": {
     "node": ">=4.1.0"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://opensource.org/licenses/MIT"
-  }
+  "license": "MIT"
 }

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -5,7 +5,7 @@ export class Cookie {
 
 	/**
 	 * Checks the existence of a single cookie by it's name
-	 * 
+	 *
 	 * @param  {string} name Identification of the cookie
 	 * @returns existence of the cookie
 	 */
@@ -30,7 +30,7 @@ export class Cookie {
 			return decodeURIComponent(result[1]);
 		} else {
 			return '';
-		}	
+		}
 	}
 
 	/**
@@ -74,7 +74,7 @@ export class Cookie {
 				cookieStr += 'expires=' + expires.toUTCString() + ';';
 			}
 		}
-		 
+
 		if (path) {
 			cookieStr += 'path=' + path + ';';
 		}
@@ -97,10 +97,7 @@ export class Cookie {
 	 * @param  {string} domain Domain where the cookie should be avaiable. Default current domain
 	 */
 	public static delete(name: string, path?: string, domain?: string) {
-		// If the cookie exists
-		if (Cookie.get(name)) {
-			Cookie.set(name, '', -1, path, domain);
-		}
+		Cookie.set(name, '', -1, path, domain);
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,0 @@
-export * from './cookie';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,27 @@
 {
   "compilerOptions": {
     "noImplicitAny": true,
-    "module": "commonjs",
-    "target": "ES5",
+    "module": "es2015",
+    "target": "es5",
+    "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "lib": [
+      "dom",
+      "es2015"
+    ]
   },
   "files": [
-    "src/index.ts",
+    "index.ts",
     "src/cookie.ts"
   ],
   "exclude": [
     "node_modules"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true,
+    "skipTemplateCodegen": true
+  }
 }


### PR DESCRIPTION
@carcamano This is a scenario where we build with AoT module bundle with `ngc` instead of `tsc`.

It also closes #36 

I think that because of the fix, we should generate a new release. Could you do that?
[]'s 