### PR TITLE
fix(Delete): Empty cookies not deleted

### DIFF
--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -97,10 +97,7 @@ export class Cookie {
 	 * @param  {string} domain Domain where the cookie should be avaiable. Default current domain
 	 */
 	public static delete(name: string, path?: string, domain?: string) {
-		// If the cookie exists
-		if (Cookie.get(name)) {
-			Cookie.set(name, '', -1, path, domain);
-		}
+		Cookie.set(name, '', -1, path, domain);
 	}
 
 	/**


### PR DESCRIPTION
Check if cookie exists before deleting it, prevents to delete empty cookies.
So, delete it, if it doesn't exists, no error is thrown.