### PR TITLE
Missing parenthesis

### DIFF
--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -117,4 +117,4 @@ export class CookieService {
 
 }
 
-export const Cookie = new CookieService;
+export const Cookie = new CookieService();


### PR DESCRIPTION
Missing parenthesis causes compilation error when using angular AoT