### PR TITLE
Prevent double regex testing when getting a cookie

### DIFF
--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -27,10 +27,11 @@ export class CookieService {
 	 * @returns The Cookie's value
 	 */
 	public get(name: string): string {
-		if (this.check(name)) {
-			name = encodeURIComponent(name);
-			let regexp = new RegExp('(?:^' + name + '|;\\s*' + name + ')=(.*?)(?:;|$)', 'g');
-			let result = regexp.exec(document.cookie);
+		if (typeof document === "undefined") return '';
+		name = encodeURIComponent(name);
+		let regexp = new RegExp('(?:^' + name + '|;\\s*' + name + ')=(.*?)(?:;|$)', 'g');
+		let result = regexp.exec(document.cookie);
+		if (result && !!result[0] && !!result[1]) {
 			return decodeURIComponent(result[1]);
 		} else {
 			return '';


### PR DESCRIPTION
When pulling a cookie value, the previous version was checking if it existed first (via REGEX) and then executing the same regex again to pull matches. While the `.test()` to check if it exists is going to be slightly quicker, it's still parsing the entire cookie set twice which adds overhead when reading an individual cookie.