### PR TITLE
Explicitly define default path on set

### DIFF
--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -80,9 +80,10 @@ export class CookieService {
 			}
 		}
 
-		if (path) {
-			cookieStr += 'path=' + path + ';';
+		if (!path) {
+			path = '/';
 		}
+		cookieStr += 'path=' + path + ';';
 		if (domain) {
 			cookieStr += 'domain=' + domain + ';';
 		}


### PR DESCRIPTION
This makes it work in IE/Edge without specifying a path.

See: https://stackoverflow.com/a/28119715

I had to specify `path='\'`on delete to get my cookies to delete in IE11 and Edge. Even when they were created without specifying a path on set.

This should fix #62 