### PR TITLE
Ensure path is set to default when deleting a cookie with missing path

### DIFF
--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -103,6 +103,9 @@ export class CookieService {
 	 * @param  {string} domain Domain where the cookie should be avaiable. Default current domain
 	 */
 	public delete(name: string, path?: string, domain?: string): void {
+		if (!path) {
+			path = '/';
+		}
 		this.set(name, '', -1, path, domain);
 	}
 


### PR DESCRIPTION
When deleting a cookie, set the default path to `/` if the cookie path isn't specified. We've got the default path set to `/` when setting a cookie.